### PR TITLE
Less Logging

### DIFF
--- a/src/main/java/io/github/pixee/maven/operator/Ignorable.kt
+++ b/src/main/java/io/github/pixee/maven/operator/Ignorable.kt
@@ -1,0 +1,11 @@
+package io.github.pixee.maven.operator
+
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+
+/**
+ * Internal Tag Object for Ignorable Messages
+ */
+object Ignorable {
+    internal val LOGGER: Logger = LoggerFactory.getLogger(Ignorable::class.java)
+}

--- a/src/main/java/io/github/pixee/maven/operator/POMScanner.kt
+++ b/src/main/java/io/github/pixee/maven/operator/POMScanner.kt
@@ -1,5 +1,6 @@
 package io.github.pixee.maven.operator
 
+import org.apache.maven.model.building.ModelBuildingException
 import org.dom4j.Element
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
@@ -21,7 +22,11 @@ object POMScanner {
         val parentPoms: List<File> = try {
             getParentPoms(originalFile)
         } catch (e: Exception) {
-            LOGGER.warn("While trying embedder: ", e)
+            if (e is ModelBuildingException) {
+                Ignorable.LOGGER.debug("mbe (you can ignore): ", e)
+            } else {
+                LOGGER.warn("While trying embedder: ", e)
+            }
 
             return legacyScanFrom(originalFile, topLevelDirectory)
         }
@@ -133,9 +138,10 @@ object POMScanner {
 
 
     private fun getParentPoms(originalFile: File): List<File> {
-        val embedderFacadeResponse = EmbedderFacade.invokeEmbedder(
-            EmbedderFacadeRequest(offline = true, pomFile = originalFile)
-        )
+        val embedderFacadeResponse =
+            EmbedderFacade.invokeEmbedder(
+                EmbedderFacadeRequest(offline = true, pomFile = originalFile)
+            )
 
         val res = embedderFacadeResponse.modelBuildingResult
 

--- a/src/main/java/io/github/pixee/maven/operator/QueryByResolver.kt
+++ b/src/main/java/io/github/pixee/maven/operator/QueryByResolver.kt
@@ -41,7 +41,7 @@ class QueryByResolver : AbstractQueryCommand() {
         try {
             embedderFacadeResponse = EmbedderFacade.invokeEmbedder(req)
         } catch (mbe: ModelBuildingException) {
-            LOGGER.warn("Oops:", mbe)
+            Ignorable.LOGGER.debug("mbe (you can ignore): ", mbe)
 
             return false
         }

--- a/src/main/java/io/github/pixee/maven/operator/UnwrapEffectivePom.kt
+++ b/src/main/java/io/github/pixee/maven/operator/UnwrapEffectivePom.kt
@@ -1,5 +1,6 @@
 package io.github.pixee.maven.operator
 
+import org.apache.maven.model.building.ModelBuildingException
 import org.codehaus.plexus.util.xml.Xpp3Dom
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
@@ -13,7 +14,12 @@ class UnwrapEffectivePom : AbstractVersionCommand() {
         try {
             executeInternal(pm)
         } catch (e: Exception) {
-            LOGGER.warn("Failure", e)
+
+            if (e is ModelBuildingException) {
+                Ignorable.LOGGER.debug("mbe (you can ignore): ", e)
+            } else {
+                LOGGER.warn("While trying embedder: ", e)
+            }
             false
         }
 


### PR DESCRIPTION
# Description

ModelBuildExceptions are expected when running offline. This PR just redirects those messages into a logger we can safely turn off in production

# Checklist:

- [X] I did my own review
- [X] Commented Code - particularly in hard sections
- [X] Docs (Javadocs)
- [X] No TODOs / Issues on Code
- [X] Tests: Unit Testing
- [X] Tests: Assertions Look Good and Sane
- [X] Tests: Coverage
- [X] Integration Testing
- [X] Java Test Fixtures
- [X] Security Risks Considered and Addressed / Mitigated
 